### PR TITLE
fix(helm): typo in values.yaml

### DIFF
--- a/config/helmchart/values.yaml.tpl
+++ b/config/helmchart/values.yaml.tpl
@@ -38,4 +38,4 @@ kube_rbac_proxy:
       memory: 20Mi
 
 enableMonitoring: true
-enableCertMAnager: false
+enableCertManager: false


### PR DESCRIPTION
typo is causing helm to ignore the certificate.yaml even then when it's set to true