### PR TITLE
disable serving-cert-secret-name annotation when cert-manager enabled

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,8 +3,10 @@ kind: Service
 metadata:
   labels:
     control-plane: patch-operator
+  {{ if not .Values.enableCertManager }}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: patch-operator-certs      
+    service.alpha.openshift.io/serving-cert-secret-name: patch-operator-certs
+  {{ end }}
   name: controller-manager-metrics-service
   namespace: system
 spec:


### PR DESCRIPTION
When using Helm to deploy the operator with `enableCertManager=true`, the `service.alpha.openshift.io/serving-cert-secret-name: patch-operator-certs` annotation on the `controller-manager-metrics-service` svc causes the cert-manager operator to contend with built-in platform certificate issuing operations.

I'm reasonably certain that only one of the two techniques for issuing certificates should be enabled at any given time. If that assumption is correct, then the change in this PR only adds the `serving-cert-secret-name` annotation if cert-manager is not enabled. In my testing, this resolves the contention.