### PR TITLE
Increase Memory Limit to 1Gi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            memory: 500Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi


### PR DESCRIPTION
On a big cluster, with several patches, I get an average memory usage of
800Mi. With a limit at 500Mi, the manager get OOMKilled.