### PR TITLE
Namespace field missing for Deployment manifest

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "patch-operator.fullname" . }}
   labels:
     {{- include "patch-operator.labels" . | nindent 4 }}
+  namespace: {{ include "patch-operator.fullname" . }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This PR will add a namespace field for deployment manifest .

Got an issue when deploying the helm charts via Argocd.

Namespace for namespace-configuration-operator apps/v1, Kind=Deployment is missing.