### PR TITLE
Fix namespace rendering in Helm chart

### DIFF
--- a/config/helmchart/templates/certificate.yaml
+++ b/config/helmchart/templates/certificate.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
@@ -10,6 +11,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - patch-operator-webhook-service.{{ .Release.Namespace }}.svc
@@ -23,6 +25,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: metrics-serving-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - patch-operator-controller-manager-metrics-service.{{ .Release.Namespace }}.svc

--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "patch-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "patch-operator.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
When using the Helm chart through rendering e.g. Kustomize / Argo CD the namespace usage is inconsistent causing deployments to fail.

This CL adds namespace to Deployment and Certificate Objects to ensure they're created in the proper namespace.